### PR TITLE
Fix FS blob storage list implementation

### DIFF
--- a/tests/test_blob_fs.py
+++ b/tests/test_blob_fs.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from tempfile import TemporaryDirectory
+
+from devdummies.fakes.blob_fs import FSBlobStorage
+
+
+def test_fs_blob_storage_roundtrip_and_listing() -> None:
+    with TemporaryDirectory() as tmp:
+        storage = FSBlobStorage(tmp)
+
+        storage.put("docs/a.txt", b"hello")
+        storage.put("docs/b.txt", b"world")
+        storage.put("logs/a.txt", b"log")
+
+        assert storage.exists("docs/a.txt")
+        assert storage.get("docs/a.txt") == b"hello"
+
+        listed = storage.list(prefix="docs/")
+        assert listed == ["docs/a.txt", "docs/b.txt"]
+
+        storage.delete("docs/a.txt")
+        assert not storage.exists("docs/a.txt")
+
+        # Ensure we didn't create any directories on reads
+        assert not (storage.root / "missing").exists()


### PR DESCRIPTION
## Summary
- correct the file-system blob storage fake to avoid creating directories on read operations and to provide a working list implementation
- ensure listed keys are filtered by prefix and returned in a stable order
- add regression test covering the blob storage fake end-to-end behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc8192bb988324aaf79e71d07c12db