### PR TITLE
Implement filesystem blob listing and tests

### DIFF
--- a/src/devdummies/fakes/blob_fs.py
+++ b/src/devdummies/fakes/blob_fs.py
@@ -27,11 +27,13 @@ class FSBlobStorage(BlobStorage):
         return self._path(key).exists()
 
     def list(self, prefix: str = "") -> list[str]:
-        out: list[str] = []
-        for p in self.root.rglob("*"):
-            if p.is_file():
-                rel = p.relative_to(self.root).as_posix()
-                if rel.startswith(prefix):
-                    out.append(rel)
-        out.sort()
-        return out
+        keys: list[str] = []
+        for path in self.root.rglob("*"):
+            if not path.is_file():
+                continue
+            key = path.relative_to(self.root).as_posix()
+            if prefix and not key.startswith(prefix):
+                continue
+            keys.append(key)
+        keys.sort()
+        return keys

--- a/tests/test_blob_fs.py
+++ b/tests/test_blob_fs.py
@@ -24,3 +24,24 @@ def test_fs_blob_storage_roundtrip_and_listing() -> None:
 
         # Ensure we didn't create any directories on reads
         assert not (storage.root / "missing").exists()
+
+
+def test_fs_blob_storage_list_filters_and_sorts(tmp_path) -> None:
+    storage = FSBlobStorage(str(tmp_path))
+
+    storage.put("root.txt", b"root")
+    storage.put("docs/a.txt", b"a")
+    storage.put("docs/b.txt", b"b")
+    storage.put("docs/notes/c.txt", b"c")
+
+    assert storage.list() == [
+        "docs/a.txt",
+        "docs/b.txt",
+        "docs/notes/c.txt",
+        "root.txt",
+    ]
+    assert storage.list(prefix="docs/") == [
+        "docs/a.txt",
+        "docs/b.txt",
+        "docs/notes/c.txt",
+    ]


### PR DESCRIPTION
## Summary
- adjust the filesystem-backed blob storage fake to walk the root directory and filter keys by prefix when listing objects
- add coverage that exercises listing behaviour, including prefix filtering and sort order

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc852052188324a6d242a942f8ceec