### PR TITLE
Avoid creating directories on blob storage reads

### DIFF
--- a/src/devdummies/fakes/blob_fs.py
+++ b/src/devdummies/fakes/blob_fs.py
@@ -8,14 +8,16 @@ class FSBlobStorage(BlobStorage):
         self.root = Path(root)
         self.root.mkdir(parents=True, exist_ok=True)
 
-    def _path(self, key: str, *, create_parent: bool = False) -> Path:
-        p = self.root / key
-        if create_parent:
-            p.parent.mkdir(parents=True, exist_ok=True)
-        return p
+    def _path(self, key: str) -> Path:
+        return self.root / key
+
+    def _path_for_write(self, key: str) -> Path:
+        path = self._path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
 
     def put(self, key: str, data: bytes) -> None:
-        self._path(key, create_parent=True).write_bytes(data)
+        self._path_for_write(key).write_bytes(data)
 
     def get(self, key: str) -> bytes:
         return self._path(key).read_bytes()

--- a/tests/test_blob_fs.py
+++ b/tests/test_blob_fs.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from devdummies.fakes.blob_fs import FSBlobStorage
 
 
@@ -24,3 +26,18 @@ def test_fs_blob_storage_roundtrip_and_listing() -> None:
 
         # Ensure we didn't create any directories on reads
         assert not (storage.root / "missing").exists()
+
+
+def test_read_helpers_do_not_create_parents_for_missing_nested_key() -> None:
+    with TemporaryDirectory() as tmp:
+        storage = FSBlobStorage(tmp)
+
+        missing_key = "nested/path/file.txt"
+
+        assert not storage.exists(missing_key)
+        assert not (storage.root / "nested").exists()
+
+        with pytest.raises(FileNotFoundError):
+            storage.get(missing_key)
+
+        assert not (storage.root / "nested").exists()


### PR DESCRIPTION
## Summary
- split the filesystem blob storage path helpers so read helpers avoid creating directories
- add a regression test ensuring read helpers do not create intermediate directories for missing nested keys

## Testing
- PYTHONPATH=src pytest tests/test_blob_fs.py

------
https://chatgpt.com/codex/tasks/task_e_68cc85214af083248f7f624a61c22f07