### PR TITLE
Make FakeClock default deterministic

### DIFF
--- a/src/devdummies/core/clock.py
+++ b/src/devdummies/core/clock.py
@@ -2,14 +2,22 @@ from __future__ import annotations
 from typing import Protocol
 from datetime import datetime, timedelta, timezone
 
+
+_DEFAULT_FAKE_CLOCK_START = datetime(2000, 1, 1, tzinfo=timezone.utc)
+
 class Clock(Protocol):
     def now(self) -> datetime: ...
     def sleep(self, delta: timedelta) -> None: ...
 
 class FakeClock:
-    """[Test Double: Fake] Deterministic clock you can advance manually."""
+    """[Test Double: Fake] Deterministic clock you can advance manually.
+
+    When ``start`` is omitted the clock begins at a fixed UTC timestamp so that
+    repeated instantiations remain deterministic.
+    """
+
     def __init__(self, start: datetime | None = None) -> None:
-        self._t = (start or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        self._t = (start or _DEFAULT_FAKE_CLOCK_START).astimezone(timezone.utc)
 
     def now(self) -> datetime:
         return self._t

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -7,3 +7,7 @@ def test_fake_clock_advances():
     t0 = c.now()
     c.sleep(timedelta(seconds=5))
     assert (c.now() - t0).total_seconds() == 5
+
+
+def test_fake_clock_default_is_deterministic():
+    assert FakeClock().now() == FakeClock().now()


### PR DESCRIPTION
## Summary
- initialize `FakeClock` with a fixed UTC epoch when no start value is provided to keep it deterministic
- document the deterministic default timestamp in the `FakeClock` docstring
- add a regression test ensuring repeated default instantiations return the same timestamp

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc996784e883248e6cf5610eb93dbe