### PR TITLE
Fix Starlette capitalization in docstring

### DIFF
--- a/src/devdummies/emulators/http_asgi.py
+++ b/src/devdummies/emulators/http_asgi.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 def create_minimal_app():
     """[Emulator] Return a minimal Starlette app for testing webhooks.
 
-    Requires optional dependency: starlette.
+    Requires optional dependency: Starlette.
     """
     try:
         from starlette.applications import Starlette


### PR DESCRIPTION
## Summary
- fix the Starlette capitalization in the `create_minimal_app` docstring

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc996989308324a0ddff7738aa0431