### PR TITLE
Normalize HttpStub route methods

### DIFF
--- a/src/devdummies/stubs/http_stub.py
+++ b/src/devdummies/stubs/http_stub.py
@@ -6,7 +6,10 @@ RequestKey = Tuple[str, str]  # (method, path)
 class HttpStub:
     """[Stub] Route table mapping (METHOD, PATH) -> handler() -> (status, headers, body)."""
     def __init__(self, routes: Mapping[RequestKey, Callable[[], tuple[int, dict, str]]]):
-        self.routes = dict(routes)
+        self.routes = {
+            (method.upper(), path): handler
+            for (method, path), handler in routes.items()
+        }
         self.calls: list[RequestKey] = []
 
     def request(self, method: str, path: str) -> tuple[int, dict, str]:

--- a/tests/test_http_stub.py
+++ b/tests/test_http_stub.py
@@ -10,3 +10,14 @@ def test_http_stub_routes_and_calls():
     assert stub.calls == [("GET", "/ping")]
     status, _, _ = stub.request("GET", "/missing")
     assert status == 404
+
+
+def test_http_stub_normalizes_registered_methods():
+    stub = HttpStub({
+        ("post", "/submit"): lambda: (201, {}, "created")
+    })
+
+    status, _, body = stub.request("POST", "/submit")
+
+    assert status == 201 and body == "created"
+    assert stub.calls == [("POST", "/submit")]


### PR DESCRIPTION
## Summary
- normalize HttpStub route keys to use uppercase methods during registration
- add a regression test confirming lowercase registrations are callable and tracked in calls

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'devdummies')*

------
https://chatgpt.com/codex/tasks/task_e_68cc9968f6d08324934bed2f24cfdc41