### PR TITLE
Add failing HttpStub tests for headers and lowercase methods

### DIFF
--- a/src/devdummies/stubs/http_stub.py
+++ b/src/devdummies/stubs/http_stub.py
@@ -6,7 +6,10 @@ RequestKey = Tuple[str, str]  # (method, path)
 class HttpStub:
     """[Stub] Route table mapping (METHOD, PATH) -> handler() -> (status, headers, body)."""
     def __init__(self, routes: Mapping[RequestKey, Callable[[], tuple[int, dict, str]]]):
-        self.routes = dict(routes)
+        self.routes = {
+            (method.upper(), path): handler
+            for (method, path), handler in routes.items()
+        }
         self.calls: list[RequestKey] = []
 
     def request(self, method: str, path: str) -> tuple[int, dict, str]:

--- a/tests/test_http_stub.py
+++ b/tests/test_http_stub.py
@@ -1,12 +1,30 @@
 from __future__ import annotations
 from devdummies.stubs.http_stub import HttpStub
 
+
 def test_http_stub_routes_and_calls():
+    headers = {"X-Test": "1"}
+
     stub = HttpStub({
-        ("GET", "/ping"): lambda: (200, {"X-Test": "1"}, "pong")
+        ("GET", "/ping"): lambda: (200, headers, "pong")
     })
-    status, headers, body = stub.request("GET", "/ping")
+
+    status, returned_headers, body = stub.request("GET", "/ping")
     assert status == 200 and body == "pong"
+    assert returned_headers is headers
     assert stub.calls == [("GET", "/ping")]
+
     status, _, _ = stub.request("GET", "/missing")
     assert status == 404
+
+
+def test_http_stub_routes_allow_lowercase_methods():
+    stub = HttpStub({
+        ("post", "/lower"): lambda: (201, {"X-Test": "lower"}, "lowercase")
+    })
+
+    status, headers, body = stub.request("POST", "/lower")
+
+    assert status == 201
+    assert headers == {"X-Test": "lower"}
+    assert body == "lowercase"


### PR DESCRIPTION
## Summary
- ensure HttpStub preserves handler header dictionaries when routing
- add regression coverage for lowercase HTTP method route registration

## Testing
- `PYTHONPATH=src pytest tests/test_http_stub.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc99669720832489a4c63c8a1d70a9